### PR TITLE
[FIXED] : Share Icons clashes with the Quotes Text

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -73,8 +73,9 @@ main {
 .quote {
   text-align: center;
   box-sizing: border-box;
-  padding: 20px 10px;
-  margin: 30px auto;
+  padding: 10px 10px;
+  /* margin: 80px auto; */
+  margin: 80px auto 10px auto;
   max-width: 1000px;
   cursor: pointer;
   position: relative;
@@ -104,7 +105,7 @@ main {
 }
 .controller {
   border-radius: 8px;
-  padding: 30px;
+  padding: 20px;
   width: 60%;
   margin: 10px auto;
   position: relative;
@@ -158,9 +159,10 @@ main {
 }
 .share-buttons {
   margin-top: 6rem;
+  margin-bottom: 0.5rem;
   display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
+  flex-direction: row-reverse;
+  gap: 0.6rem;
   justify-content: center;
   align-items: end;
   position: absolute;
@@ -201,7 +203,8 @@ main {
   width: 60%;
   text-align: center;
   display: inline-block;
-  margin: 0 auto;
+  /* margin: 0 auto; */
+  margin: 2px auto;
   padding: 10px 20px;
   border-radius: 0 0 5px 5px;
   border-top: 0.5px solid rgba(255, 255, 255, 0.515);
@@ -353,7 +356,7 @@ body {
 /* copy button */
 
 .share-buttons .icon {
-  padding: 8px 9px;
+  padding: 6px 8px;
   background: #1a232d;
   color: #fff;
   font-size: 16px;
@@ -361,6 +364,11 @@ body {
   outline: none;
   border-radius: 10px;
   cursor: pointer;
+  transition: opacity 0.5s ease-in-out;
+}
+
+.share-buttons .icon:hover {
+  font-size: 20px;
   transition: opacity 0.5s ease-in-out;
 }
 


### PR DESCRIPTION
# PULL REQUEST TEMPLATE

**My PR closes issue #86** <!-- Mandary for feature and bug -->

### 👨‍💻 What did you do ?

I aligned the share buttons horizontally so that it does not overlaps on Quotes Text.

<!-- Explain your changes here -->
## Bugs fixed:

 - [x] Align the share buttons horizontally
 - [x] Align the quotes text with share buttons when horizontally aligned

# 📷 Screenshots <!-- Mandatory for bug fix and feature addition  -->

<img width="960" alt="Screenshot 2023-10-21 131953" src="https://github.com/Shariar-Hasan/QuoteVerse/assets/96042938/b3d75043-1ded-4eaf-99c1-7594f1af8fec">



### ✔️ Check List (Check all the applicable boxes)

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I have read the [contribution guideline](https://github.com/Shariar-Hasan/QuoteVerse/blob/main/Contributing.md) properly and following the criteria.

