### PR TITLE
feat: share tile

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -149,9 +149,9 @@ main {
   transform: translateY(-20%);
   transition: all 0.35s ease-in-out;
   border-radius: 20px;
-  box-shadow: 0 15px 25px rgba(129, 124, 124, 0.2);
   backdrop-filter: blur(14px);
-  background-color: rgba(255, 255, 255, 0.2);
+  border-top: 0.5px solid rgba(255, 255, 255, 0.515);
+  background-color: #262626;
   padding: 10px;
 }
 .shareWith:hover .share-buttons {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -148,6 +148,11 @@ main {
   opacity: 0;
   transform: translateY(-20%);
   transition: all 0.35s ease-in-out;
+  box-shadow: 0 15px 25px rgba(129, 124, 124, 0.2);
+  backdrop-filter: blur(14px);
+  background-color: rgba(255, 255, 255, 0.2);
+  padding: 10px;
+  border-radius: 20px;
 }
 .shareWith:hover .share-buttons {
   visibility: visible;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -148,11 +148,11 @@ main {
   opacity: 0;
   transform: translateY(-20%);
   transition: all 0.35s ease-in-out;
+  border-radius: 20px;
   box-shadow: 0 15px 25px rgba(129, 124, 124, 0.2);
   backdrop-filter: blur(14px);
   background-color: rgba(255, 255, 255, 0.2);
   padding: 10px;
-  border-radius: 20px;
 }
 .shareWith:hover .share-buttons {
   visibility: visible;


### PR DESCRIPTION
# Added a transparent tile for clear visibility of the Share buttons

***this PR closes #100 *

I added a transparent tile neat the share option. because when the color is changed the standard whatsapp, twitter and facebook logos are mixed and become hard to see.


# 📷 Screenshots
Previously it kind of looks like this.
![Screenshot 2023-10-22 002133](https://github.com/Shariar-Hasan/QuoteVerse/assets/121670156/ac600a11-f6ba-46c4-951a-609c42668cb2)

After few changes and all the colors considered a lighter color will suit the Interface so added a transparent tile
![Screenshot 2023-10-22 005252](https://github.com/Shariar-Hasan/QuoteVerse/assets/121670156/960556a8-3ff5-4737-beeb-8a350f5040c8)



### ✔️ Check List (Check all the applicable boxes)

- [x] Opera
- [x] Chrome
- [x] Firefox

### 📃I Can assure u that

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I have read the [contribution guideline](https://github.com/Shariar-Hasan/QuoteVerse/blob/main/Contributing.md) properly and following the criteria.
